### PR TITLE
Add error to console, do not eat error

### DIFF
--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-error.service.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-error.service.ts
@@ -37,6 +37,8 @@ export class ApplicationinsightsAngularpluginErrorService implements IErrorServi
     }
 
     handleError(error: any): void {
+        console.error(error);
+
         if (this.analyticsPlugin) {
             this.analyticsPlugin.trackException({ exception: error });
         }


### PR DESCRIPTION
Currently when using `ApplicationinsightsAngularpluginErrorService` as error handler, users can't see error in browser console. This is not friendly when development in local environment, because not all developers in the team has access to Azure to view application insights data.

This PR is for adding the error log to console, so that users can see error immediately without going to Azure.