### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
     "@microsoft/applicationinsights-analytics-js": "^2.8.5",
     "@angular/common": ">= 14.0.3",
     "@angular/core": ">= 14.0.3"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
According to the LICENSE file the project is under MIT license, but this information is not published in the package.json file.

Adding this information to the package.json under the standard "license" field will help automated tools correctly identify the license for compliance check or attribution.