### PR TITLE
fix(deps): apply non-breaking npm audit fixes and normalize lockfile registry URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "node_modules/@angular-devkit/build-angular": {
             "version": "15.2.11",
             "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.11.tgz",
-            "integrity": "sha512-MnpVCJdk5jHuK7CH/cTcRT0JQkkKkRTEV3WTyOUhTm0O3PlKwvTM6/Sner+zyuhKyw5VFBBMypHh59aTUDEZ1A==",
+            "integrity": "sha1-EjXUXG1BeRLQHvP7ytFGX8uKgdI=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -217,7 +217,7 @@
         "node_modules/@angular-devkit/build-webpack": {
             "version": "0.1502.11",
             "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.11.tgz",
-            "integrity": "sha512-OTONIRp770Jfems4+cULmtoeSzjnpx5UjV2EazojnhRXXBSJMWRMPvwD2QvQl9UO/6eOV3d2mgmP2xOZgc/D6w==",
+            "integrity": "sha1-7sTc14NVdAEwXcV3eK1fHwnNbfM=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -375,8 +375,10 @@
         "node_modules/@angular/animations": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-15.2.10.tgz",
-            "integrity": "sha512-yxfN8qQpMaukRU5LjFkJBmy85rqrOp86tYVCsf+hmPEFRiXBMUj6xYLeCMcpk3Mt1JtnWGBR34ivGx+7bNeAow==",
+            "integrity": "sha1-yRlLqaK5tORm6cduGFkc3glqKOg=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -390,9 +392,10 @@
         "node_modules/@angular/cli": {
             "version": "15.2.11",
             "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.11.tgz",
-            "integrity": "sha512-fsIMvUWVCZM3qQSKZXR0yHTXxvoNrbs/PDUsGhRjWZrfUDHBCzMmKral5x8onMA/KPU9O3JiolKjiKVwzkudJA==",
+            "integrity": "sha1-5yxjMErQ8bTmSDcrHB7ryQJFIbE=",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/architect": "0.1502.11",
                 "@angular-devkit/core": "15.2.11",
@@ -425,8 +428,10 @@
         "node_modules/@angular/common": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.10.tgz",
-            "integrity": "sha512-jdBn3fctkqoNrJn9VLsUHpcCEhCxWSczdsR+BBbD6T0oLl6vMrAVNjPwfBejnlgfWN1KoRU9kgOYsMxa5apIWQ==",
+            "integrity": "sha1-iXkjAjyMpKNhziGL3umj8JBg33U=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -441,8 +446,9 @@
         "node_modules/@angular/compiler": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.10.tgz",
-            "integrity": "sha512-M0XkeU0O73UlJZwDvOyp8/apetz9UKj78eTFDseMYJDLcxe6MpkbkxqpsGZnKYDj7LIep8PmCAKEkhtenE82zw==",
+            "integrity": "sha1-vXjzJ9EutZePndBUQKoj1LW5Jak=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -461,8 +467,10 @@
         "node_modules/@angular/compiler-cli": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.10.tgz",
-            "integrity": "sha512-mCFIxrs60XicKfA2o42hA7LrQvhybi9BQveWuZn/2iIEOXx7R62Iemz8E21pLWftAZHGxEW3NECfBrY1d3gVmA==",
+            "integrity": "sha1-5RATqg89owP8dPjhlIxVDY506tU=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.19.3",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -491,8 +499,9 @@
         "node_modules/@angular/compiler-cli/node_modules/@babel/core": {
             "version": "7.19.3",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-            "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+            "integrity": "sha1-JRn2KlFFj0O2gtYVg8OBDn3O5kw=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -542,8 +551,10 @@
         "node_modules/@angular/core": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.10.tgz",
-            "integrity": "sha512-meGGidnitQJGDxYd9/LrqYiVlId+vGaLoiLgJdKBz+o2ZO6OmXQGuNw2VBqf17/Cc0/UjzrOY7+kILNFKkk/WQ==",
+            "integrity": "sha1-k8Hg1GDSFxFlTFeNJwmkAuGCICM=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -558,8 +569,9 @@
         "node_modules/@angular/forms": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.10.tgz",
-            "integrity": "sha512-NIntGsNcN6o8L1txsbWXOf6f3K/CUBizdKsxsYVYGJIXEW5qU6UnWmfAZffNNXsT/XvbgUCjgDwT0cAwcqZPuQ==",
+            "integrity": "sha1-CTCOiH3y+k00kwDJ0fBcrfs4crM=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -576,8 +588,10 @@
         "node_modules/@angular/platform-browser": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.10.tgz",
-            "integrity": "sha512-9tbgVGSJqwfrOzT8aA/kWBLNhJSQ9gUg0CJxwFBSJm8VkBUJrszoBlDsnSvlxx8/W2ejNULKHFTXeUzq0O/+RQ==",
+            "integrity": "sha1-ylqQS02p4M9xlBTbiVFO5CIcuT0=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -598,8 +612,9 @@
         "node_modules/@angular/platform-browser-dynamic": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-15.2.10.tgz",
-            "integrity": "sha512-JHP6W+FX715Qv7DhqvfZLuBZXSDJrboiQsR06gUAgDSjAUyhbqmpVg/2YOtgeWpPkzNDtXdPU2PhcRdIv5J3Yg==",
+            "integrity": "sha1-zJrT3N7Wy5Re6MTu8U2wgdxsPf0=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -616,8 +631,9 @@
         "node_modules/@angular/router": {
             "version": "15.2.10",
             "resolved": "https://registry.npmjs.org/@angular/router/-/router-15.2.10.tgz",
-            "integrity": "sha512-LmuqEg0iIXSw7bli6HKJ19cbxP91v37GtRwbGKswyLihqzTgvjBYpvcfMnB5FRQ5LWkTwq5JclkX03dZw290Yg==",
+            "integrity": "sha1-pdMtdpuTDpBVgu1seqgSLmNlVzg=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -658,8 +674,10 @@
         "node_modules/@babel/core": {
             "version": "7.20.12",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-            "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+            "integrity": "sha1-eTDbV0Q8ZxStIWlT0TVtrA64SW0=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -2988,9 +3006,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3081,9 +3099,9 @@
             "license": "MIT"
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3350,7 +3368,7 @@
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "integrity": "sha1-z46p3LhJuByV8U/AqqFRxrVNJXg=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3367,7 +3385,7 @@
         "node_modules/@jsonjoy.com/buffers": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
-            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "integrity": "sha1-XFjbze6ogkzilr0c/OAGwusWez0=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3384,7 +3402,7 @@
         "node_modules/@jsonjoy.com/codegen": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
-            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "integrity": "sha1-XCP3lsR2dfFm0juUjNuIkYS5Mgc=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3399,14 +3417,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-core": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.8.tgz",
-            "integrity": "sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.67.0.tgz",
+            "integrity": "sha1-5aiVW9UibGgi47p5qsvbI6Szi9o=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-builtins": "4.57.8",
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
                 "thingies": "^2.5.0"
             },
             "engines": {
@@ -3421,15 +3439,15 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-fsa": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.8.tgz",
-            "integrity": "sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.67.0.tgz",
+            "integrity": "sha1-IbFHSa8c8kradpx+ptvTpp269AM=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.8",
-                "@jsonjoy.com/fs-node-builtins": "4.57.8",
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
+                "@jsonjoy.com/fs-core": "4.67.0",
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
                 "thingies": "^2.5.0"
             },
             "engines": {
@@ -3444,17 +3462,17 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.8.tgz",
-            "integrity": "sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.67.0.tgz",
+            "integrity": "sha1-RcqIVMTYfcuqgE8xujb0toMq2kM=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.8",
-                "@jsonjoy.com/fs-node-builtins": "4.57.8",
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
-                "@jsonjoy.com/fs-print": "4.57.8",
-                "@jsonjoy.com/fs-snapshot": "4.57.8",
+                "@jsonjoy.com/fs-core": "4.67.0",
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
+                "@jsonjoy.com/fs-print": "4.67.0",
+                "@jsonjoy.com/fs-snapshot": "4.67.0",
                 "glob-to-regex.js": "^1.0.0",
                 "thingies": "^2.5.0"
             },
@@ -3470,9 +3488,9 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-builtins": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.8.tgz",
-            "integrity": "sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.67.0.tgz",
+            "integrity": "sha1-QUhsXbFEBLbwufr9GPWXKzeF4Z8=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3487,15 +3505,15 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.8.tgz",
-            "integrity": "sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.67.0.tgz",
+            "integrity": "sha1-ASQlAEuUgZMd6HTiuotzMyF6zW0=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-fsa": "4.57.8",
-                "@jsonjoy.com/fs-node-builtins": "4.57.8",
-                "@jsonjoy.com/fs-node-utils": "4.57.8"
+                "@jsonjoy.com/fs-fsa": "4.67.0",
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "@jsonjoy.com/fs-node-utils": "4.67.0"
             },
             "engines": {
                 "node": ">=10.0"
@@ -3509,13 +3527,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-node-utils": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.8.tgz",
-            "integrity": "sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.67.0.tgz",
+            "integrity": "sha1-UEr2lRhJfbmsAg8N5WIW4rZzYFA=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-builtins": "4.57.8"
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "glob-to-regex.js": "^1.0.1"
             },
             "engines": {
                 "node": ">=10.0"
@@ -3529,13 +3548,13 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-print": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.8.tgz",
-            "integrity": "sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.67.0.tgz",
+            "integrity": "sha1-zfeX2JosyjzEqA7zgUF3W6QoBL0=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
                 "tree-dump": "^1.1.0"
             },
             "engines": {
@@ -3550,14 +3569,14 @@
             }
         },
         "node_modules/@jsonjoy.com/fs-snapshot": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.8.tgz",
-            "integrity": "sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.67.0.tgz",
+            "integrity": "sha1-xVT4sDaEgePDavjnwsdSbsiBC9M=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jsonjoy.com/buffers": "^17.65.0",
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
                 "@jsonjoy.com/json-pack": "^17.65.0",
                 "@jsonjoy.com/util": "^17.65.0"
             },
@@ -3575,7 +3594,7 @@
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "integrity": "sha1-fu2jy0ETjXepBAj9LkKyq6EFdtc=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3592,7 +3611,7 @@
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "integrity": "sha1-NjX9h2nXfhm3XcVXS8l1YBmy5ZE=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3609,7 +3628,7 @@
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
-            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "integrity": "sha1-jdj/Zd2ZnF1NJt9GxjkVx73sCTo=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3636,7 +3655,7 @@
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
-            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "integrity": "sha1-dEOVc9wEbgyaOlUvuUs5G8dTE7g=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3656,7 +3675,7 @@
         "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
             "version": "17.67.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
-            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "integrity": "sha1-fEKI/DgIIz5Vx2EBAee7RZDN3T8=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3677,7 +3696,7 @@
         "node_modules/@jsonjoy.com/json-pack": {
             "version": "1.21.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
-            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "integrity": "sha1-k/jdV/46OpITKzPR6xgtzZ52Kfo=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3704,7 +3723,7 @@
         "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "integrity": "sha1-jZnH9n6vck00KN/ZgmxkVSZqXIM=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3721,7 +3740,7 @@
         "node_modules/@jsonjoy.com/json-pointer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
-            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "integrity": "sha1-BJy1MKwk6Ey6CFkMXja0McSENAg=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3742,7 +3761,7 @@
         "node_modules/@jsonjoy.com/util": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
-            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "integrity": "sha1-fulVhq7Qp2a3Rs2Ng2PjNsPEfEY=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3763,7 +3782,7 @@
         "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "integrity": "sha1-jZnH9n6vck00KN/ZgmxkVSZqXIM=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4197,7 +4216,7 @@
         "node_modules/@ngtools/webpack": {
             "version": "15.2.11",
             "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.11.tgz",
-            "integrity": "sha512-yqp+FziuJ+wIVij4eTqfhuiTPNaG1PU8ukeGOdqkVH4nQMlmzs9UldXy1iYC/6swzn6XO/pkqisU3m/jxemMzA==",
+            "integrity": "sha1-ww96+Xi8USuHRiTOD3vl0irjnm0=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4395,8 +4414,9 @@
         "node_modules/@npmcli/run-script": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
-            "integrity": "sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==",
+            "integrity": "sha1-olRS1F7n9/uMFt+vliRCPAwOuIU=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^3.0.0",
                 "@npmcli/promise-spawn": "^6.0.0",
@@ -4797,8 +4817,9 @@
         "node_modules/@sigstore/sign": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-1.0.0.tgz",
-            "integrity": "sha512-INxFVNQteLtcfGmcoldzV6Je0sbbfh9I16DM4yJPw3j5+TFP8X6uIiA18mvpEa9yyeycAKgPmOA3X9hVdVTPUA==",
+            "integrity": "sha1-awjrwvbJKqWssHpJeEy2c4eW97Q=",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^1.1.0",
                 "@sigstore/protobuf-specs": "^0.2.0",
@@ -4820,8 +4841,9 @@
         "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz",
-            "integrity": "sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==",
+            "integrity": "sha1-hc65gHlYSpUj1L9x0ymW5+IIVJ8=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
                 "cacache": "^17.0.0",
@@ -4881,8 +4903,9 @@
         "node_modules/@sigstore/tuf": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-1.0.3.tgz",
-            "integrity": "sha512-2bRovzs0nJZFlCN3rXirE4gwxCn97JNjMmwpecqlbgV9WcxX7WRuIrgzx/X7Ib7MYRbyUTpBYE0s2x6AmZXnlg==",
+            "integrity": "sha1-KmWYZ3Lt6ZZIVyjwJ7BRTAtwsWA=",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.2.0",
                 "tuf-js": "^1.1.7"
@@ -4995,16 +5018,15 @@
             "license": "MIT"
         },
         "node_modules/@types/express": {
-            "version": "4.17.25",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+            "integrity": "sha1-LXJLLJkNy4yERAY/NYCpA/bVAMw=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "^1"
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "^2"
             }
         },
         "node_modules/@types/express-serve-static-core": {
@@ -5020,35 +5042,12 @@
                 "@types/send": "*"
             }
         },
-        "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.8",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-            "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "integrity": "sha1-W3SasrFroRNCP+saZKldzTA5hHI=",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/http-proxy": {
-            "version": "1.17.17",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-            "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/jasmine": {
             "version": "3.6.11",
@@ -5067,13 +5066,6 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
-        },
-        "node_modules/@types/mime": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "12.20.55",
@@ -5107,13 +5099,6 @@
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
-        "node_modules/@types/retry": {
-            "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/semver": {
             "version": "7.5.7",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
@@ -5141,35 +5126,13 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.10",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha1-1KRHUD6tDRZxEy0atr1YuAXY3mo=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "<1"
-            }
-        },
-        "node_modules/@types/serve-static/node_modules/@types/send": {
-            "version": "0.17.6",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/mime": "^1",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/sockjs": {
-            "version": "0.3.36",
-            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
-            "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -5308,6 +5271,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -5829,6 +5793,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5928,6 +5893,7 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6122,13 +6088,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/array-includes": {
             "version": "3.1.7",
@@ -6699,16 +6658,16 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -6738,6 +6697,7 @@
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001449",
                 "electron-to-chromium": "^1.4.284",
@@ -6815,7 +6775,7 @@
         "node_modules/bundle-name": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6851,8 +6811,9 @@
         "node_modules/cacache": {
             "version": "17.0.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
-            "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
+            "integrity": "sha1-UCPtiSuohD47c2HCbQraN+FGKQw=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^3.1.0",
                 "fs-minipass": "^3.0.0",
@@ -7317,38 +7278,18 @@
             "dev": true
         },
         "node_modules/content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/content-disposition/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/content-type": {
             "version": "1.0.5",
@@ -7375,11 +7316,14 @@
             }
         },
         "node_modules/cookie-signature": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-            "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/copy-anything": {
             "version": "2.0.6",
@@ -7396,8 +7340,9 @@
         "node_modules/copy-webpack-plugin": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
-            "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
+            "integrity": "sha1-ltTb219z0C3XLQUo0ZWHIaty4Eo=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-glob": "^3.2.11",
                 "glob-parent": "^6.0.1",
@@ -7457,16 +7402,6 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/copy-webpack-plugin/node_modules/slash": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -7523,12 +7458,6 @@
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
         },
         "node_modules/cors": {
             "version": "2.8.5",
@@ -7780,7 +7709,7 @@
         "node_modules/default-browser": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7797,7 +7726,7 @@
         "node_modules/default-browser-id": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7913,19 +7842,13 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/devtools-protocol": {
             "version": "0.0.1581282",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
             "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/di": {
             "version": "0.0.1",
@@ -8424,9 +8347,10 @@
         "node_modules/esbuild": {
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.8.tgz",
-            "integrity": "sha512-g24ybC3fWhZddZK6R3uD2iF/RIPnRpwJAqLov6ouX3hMbY4+tKolP0VMF3zuIYCaXun+yHwS5IPQ91N2BT191g==",
+            "integrity": "sha1-9/eZq8fNzj8PLj4MAfEg1NVRk7Q=",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "bin": {
                 "esbuild": "bin/esbuild"
@@ -8534,6 +8458,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
             "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8686,9 +8611,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8906,9 +8831,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9156,7 +9081,7 @@
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9195,46 +9120,96 @@
             "dev": true
         },
         "node_modules/express": {
-            "version": "4.22.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "~1.20.5",
-                "content-disposition": "~0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "~0.7.1",
-                "cookie-signature": "~1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "~1.3.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.0",
-                "merge-descriptors": "1.0.3",
-                "methods": "~1.1.2",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "~0.1.12",
-                "proxy-addr": "~2.0.7",
-                "qs": "~6.15.1",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "~0.19.0",
-                "serve-static": "~1.16.2",
-                "setprototypeof": "1.2.0",
-                "statuses": "~2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "type": "opencollective",
@@ -9242,19 +9217,27 @@
             }
         },
         "node_modules/express/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/express/node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9262,60 +9245,159 @@
             }
         },
         "node_modules/express/node_modules/finalhandler": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-            "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.4.1",
-                "parseurl": "~1.3.3",
-                "statuses": "~2.0.2",
-                "unpipe": "~1.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             },
             "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/express/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/express/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+        "node_modules/express/node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
         "node_modules/express/node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/express/node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/extend": {
@@ -9401,9 +9483,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
             "dev": true,
             "funding": [
                 {
@@ -9424,19 +9506,6 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/faye-websocket": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "websocket-driver": ">=0.5.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/fd-slicer": {
@@ -9645,7 +9714,7 @@
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9666,13 +9735,13 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/fs-extra": {
@@ -9940,7 +10009,7 @@
         "node_modules/glob-to-regex.js": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
-            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "integrity": "sha1-KzI3KCcdEzgwhQ4yMR9AdmxfZBM=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -9969,9 +10038,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10060,13 +10129,6 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
-        },
-        "node_modules/handle-thing": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
@@ -10179,19 +10241,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/hpack.js": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "obuf": "^1.0.0",
-                "readable-stream": "^2.0.1",
-                "wbuf": "^1.1.0"
-            }
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10203,13 +10252,6 @@
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
             "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
             "dev": true
-        },
-        "node_modules/http-deceiver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
@@ -10242,13 +10284,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/http-parser-js": {
-            "version": "0.5.10",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-            "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/http-proxy": {
             "version": "1.18.1",
             "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -10278,29 +10313,46 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
-            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+            "integrity": "sha1-8HkPw06zxCrrTpCEFLxFTcaqJ00=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/http-proxy": "^1.17.8",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.1",
-                "is-plain-obj": "^3.0.0",
-                "micromatch": "^4.0.2"
+                "debug": "^4.4.3",
+                "httpxy": "^0.5.4",
+                "is-glob": "^4.0.3",
+                "is-plain-obj": "^4.1.0",
+                "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
+            }
+        },
+        "node_modules/http-proxy-middleware/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
             },
-            "peerDependencies": {
-                "@types/express": "^4.17.13"
+            "engines": {
+                "node": ">=6.0"
             },
             "peerDependenciesMeta": {
-                "@types/express": {
+                "supports-color": {
                     "optional": true
                 }
             }
+        },
+        "node_modules/http-proxy-middleware/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
@@ -10315,6 +10367,13 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/httpxy": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+            "integrity": "sha1-JQNjFjzJWFjcNiM7sIv5yYpV+ro=",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/humanize-ms": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -10327,7 +10386,7 @@
         "node_modules/hyperdyperid": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+            "integrity": "sha1-WWaNMjrakiKNKoadPkdNWjO2nms=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10402,8 +10461,9 @@
         "node_modules/image-size": {
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-            "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "bin": {
                 "image-size": "bin/image-size.js"
@@ -10580,9 +10640,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha1-xZELxUG26uKHdl0eSEa+AwigXZM=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10776,10 +10836,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha1-jrc8HKu6d3SNOJWI7uoTKmMFdiI=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10798,7 +10871,7 @@
         "node_modules/is-inside-container/node_modules/is-docker": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -10856,7 +10929,7 @@
         "node_modules/is-network-error": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
-            "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+            "integrity": "sha1-lGC8MPhBmkvKdxFPTeiKPuXgxRk=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10900,13 +10973,13 @@
             }
         },
         "node_modules/is-plain-obj": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -10923,6 +10996,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
@@ -11376,6 +11456,7 @@
             "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.20.tgz",
             "integrity": "sha512-HRNQhMuKOwKpjYlWiJP0DUrJOh+QjaI/DTaD8b9rEm4Il3tJ8MijutVZH4ts10LuUFst/CedwTS6vieCN8yTSw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
                 "body-parser": "^1.19.0",
@@ -11455,9 +11536,9 @@
             "license": "MIT"
         },
         "node_modules/karma-coverage/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11534,9 +11615,9 @@
             "license": "MIT"
         },
         "node_modules/karma/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11665,8 +11746,10 @@
         "node_modules/less": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
-            "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
+            "integrity": "sha1-F1vp3cv5slAXPgoAtNaSClt3AkY=",
             "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -11969,8 +12052,9 @@
         "node_modules/make-fetch-happen": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-            "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+            "integrity": "sha1-9eODXF6YF7YX8ncIcNlJLShngWQ=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
                 "cacache": "^16.1.0",
@@ -12009,8 +12093,9 @@
         "node_modules/make-fetch-happen/node_modules/cacache": {
             "version": "16.1.3",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-            "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+            "integrity": "sha1-oCufNOz6+aeMn0vBb865TV1no44=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^2.1.0",
                 "@npmcli/move-file": "^2.0.0",
@@ -12155,11 +12240,14 @@
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -12177,16 +12265,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/methods": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/micromatch": {
@@ -12263,13 +12341,6 @@
             "peerDependencies": {
                 "webpack": "^5.0.0"
             }
-        },
-        "node_modules/minimalistic-assert": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "10.2.5",
@@ -12565,9 +12636,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.17",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+            "integrity": "sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=",
             "dev": true,
             "funding": [
                 {
@@ -12653,8 +12724,10 @@
         "node_modules/ng-packagr": {
             "version": "15.2.2",
             "resolved": "https://registry.npmjs.org/ng-packagr/-/ng-packagr-15.2.2.tgz",
-            "integrity": "sha512-+042GBD35ztxbHywGJloAiDM/s3Ja3TZtQh361TWqd/xza3K5DMUu6VRGLTgMwG7CW1YsqYHWgMZslP1c+ng7A==",
+            "integrity": "sha1-KuY+jmOnsP2SAsG/d/FEv4agayk=",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rollup/plugin-json": "^6.0.0",
                 "@rollup/plugin-node-resolve": "^15.0.0",
@@ -12720,8 +12793,9 @@
         "node_modules/node-gyp": {
             "version": "9.4.1",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
-            "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+            "integrity": "sha1-ihAj4NZ2bstSdkzDpzSzb/J14YU=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
@@ -12750,9 +12824,9 @@
             "license": "MIT"
         },
         "node_modules/node-gyp/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12929,8 +13003,9 @@
         "node_modules/npm-registry-fetch": {
             "version": "14.0.5",
             "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-14.0.5.tgz",
-            "integrity": "sha512-kIDMIo4aBm6xg7jOttupWZamsZRkAqMqwqqbVXnUqstY5+tapvv6bkH/qMR76jdgV+YljEUCyWx3hRYMrJiAgA==",
+            "integrity": "sha1-/nFplXukmGpIU6ZQJ47gLlaNEV0=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^11.0.0",
                 "minipass": "^5.0.0",
@@ -12956,8 +13031,9 @@
         "node_modules/npm-registry-fetch/node_modules/make-fetch-happen": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz",
-            "integrity": "sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==",
+            "integrity": "sha1-hc65gHlYSpUj1L9x0ymW5+IIVJ8=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
                 "cacache": "^17.0.0",
@@ -13153,13 +13229,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/obuf": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -13334,31 +13403,19 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
-            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+            "integrity": "sha1-FQX68UlCMm4Y1AkfXWBbrmVjTns=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/retry": "0.12.2",
-                "is-network-error": "^1.0.0",
-                "retry": "^0.13.1"
+                "is-network-error": "^1.3.0"
             },
             "engines": {
-                "node": ">=16.17"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-retry/node_modules/retry": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/p-try": {
@@ -13467,8 +13524,9 @@
         "node_modules/pacote": {
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.1.0.tgz",
-            "integrity": "sha512-FFcjtIl+BQNfeliSm7MZz5cpdohvUV1yjGnqgVM4UnVF7JslRY0ImXAygdaCDV0jjUADEWu4y5xsDV8brtrTLg==",
+            "integrity": "sha1-LgsSpPVf/YAagTShrijvNh3D8kM=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^4.0.0",
                 "@npmcli/installed-package-contents": "^2.0.1",
@@ -13701,11 +13759,15 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha1-eVxCDE98pFxbiHNm9iLuDJhSzM0=",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -13746,7 +13808,7 @@
         "node_modules/piscina": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.0.0.tgz",
-            "integrity": "sha512-R+arufwL7sZvGjAhSMK3TfH55YdGOqhpKXkcwQJr432AAnJX/xxX19PA4QisrmJ+BTTfZVggaz6HexbkQq1l1Q==",
+            "integrity": "sha1-mk8R5LT/E36muQpmw863dVsr5W8=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13787,9 +13849,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
             "dev": true,
             "funding": [
                 {
@@ -13806,8 +13868,9 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13935,9 +13998,9 @@
             "license": "MIT"
         },
         "node_modules/postcss-url/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13976,6 +14039,19 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha1-WkLJqCT7Ty8lHMtBqq5zMU9dasI=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -14005,12 +14081,6 @@
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -14044,7 +14114,7 @@
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14058,7 +14128,7 @@
         "node_modules/proxy-addr/node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14452,27 +14522,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/readable-stream": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/readable-stream/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -14742,9 +14791,9 @@
             "license": "MIT"
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14793,6 +14842,7 @@
             "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -14804,10 +14854,52 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/router/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/router/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/run-applescript": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14854,6 +14946,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
             "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^1.9.0"
             },
@@ -14929,6 +15022,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.1.tgz",
             "integrity": "sha512-bnINi6nPXbP1XNRaranMFEBZWUfdW/AF16Ql5+ypRxfTvCRTTKrLsMIakyDcayUt2t/RZotmL4kgJwNH5xO+bg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -15006,13 +15100,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/select-hose": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/selfsigned": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
@@ -15061,85 +15148,112 @@
             "dev": true
         },
         "node_modules/send": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-            "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "~0.5.2",
-                "http-errors": "~2.0.1",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "~2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "~2.0.2"
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/send/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.0.0"
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
-        },
-        "node_modules/send/node_modules/debug/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/send/node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
-        "node_modules/send/node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+        "node_modules/send/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
             "dev": true,
             "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/send/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/send/node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha1-3voeBVyDv21Z6oBdjahiJU62psI=",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
             }
         },
         "node_modules/serve-index": {
@@ -15210,25 +15324,29 @@
             "license": "MIT"
         },
         "node_modules/serve-static": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-            "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "~0.19.1"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/serve-static/node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -15410,8 +15528,9 @@
         "node_modules/sigstore": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-1.9.0.tgz",
-            "integrity": "sha512-0Zjz0oe37d08VeOtBIuB6cRriqXse2e8w+7yIy2XSXjshRKxbc2KkhXjL229jXSxEm7UbcjS76wcJDGQddVI9A==",
+            "integrity": "sha1-HnrYkzqpm3XGiY3dDu68PrDVmHU=",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^1.1.0",
                 "@sigstore/protobuf-specs": "^0.2.0",
@@ -15438,8 +15557,9 @@
         "node_modules/sigstore/node_modules/make-fetch-happen": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz",
-            "integrity": "sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==",
+            "integrity": "sha1-hc65gHlYSpUj1L9x0ymW5+IIVJ8=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
                 "cacache": "^17.0.0",
@@ -15570,9 +15690,9 @@
             "license": "MIT"
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+            "integrity": "sha1-Z55R/iTRyB35D8X37+Sl9DL+mcA=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15607,18 +15727,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/sockjs": {
-            "version": "0.3.24",
-            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-            "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "faye-websocket": "^0.11.3",
-                "uuid": "^8.3.2",
-                "websocket-driver": "^0.7.4"
-            }
         },
         "node_modules/socks": {
             "version": "2.8.9",
@@ -15762,53 +15870,6 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
             "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
             "dev": true
-        },
-        "node_modules/spdy": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "handle-thing": "^2.0.0",
-                "http-deceiver": "^1.2.7",
-                "select-hose": "^2.0.0",
-                "spdy-transport": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/spdy-transport": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "detect-node": "^2.0.4",
-                "hpack.js": "^2.1.6",
-                "obuf": "^1.1.2",
-                "readable-stream": "^3.0.6",
-                "wbuf": "^1.7.3"
-            }
-        },
-        "node_modules/spdy-transport/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/ssri": {
             "version": "10.0.5",
@@ -16061,9 +16122,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -16291,9 +16352,9 @@
             "license": "MIT"
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16351,9 +16412,9 @@
             "dev": true
         },
         "node_modules/thingies": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-            "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha1-TrKOJYWnUojxdloLCPHfoCA1em8=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16379,6 +16440,55 @@
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/tmp": {
             "version": "0.2.7",
@@ -16415,7 +16525,7 @@
         "node_modules/tree-dump": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
-            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "integrity": "sha1-qykSkWncRgBEFPWp1KPG6J8T6KQ=",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -16488,7 +16598,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -16534,8 +16645,9 @@
         "node_modules/tuf-js": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-1.1.7.tgz",
-            "integrity": "sha512-i3P9Kgw3ytjELUfpuKVDNBJvk4u5bXL6gskv572mcevPbSKCV3zt3djhmlEQ65yERjIbOSncy7U4cQJaB1CBCg==",
+            "integrity": "sha1-Ibeukqk3MBW+d9/gyygqgOw7vkM=",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@tufjs/models": "1.0.4",
                 "debug": "^4.3.4",
@@ -16557,8 +16669,9 @@
         "node_modules/tuf-js/node_modules/make-fetch-happen": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz",
-            "integrity": "sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==",
+            "integrity": "sha1-hc65gHlYSpUj1L9x0ymW5+IIVJ8=",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
                 "cacache": "^17.0.0",
@@ -16736,6 +16849,7 @@
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16919,20 +17033,6 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/uuid": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-            "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
-            }
-        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -16996,16 +17096,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/wbuf": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimalistic-assert": "^1.0.0"
-            }
-        },
         "node_modules/wcwidth": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -17028,6 +17118,7 @@
             "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
@@ -17099,53 +17190,51 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-            "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-6.0.0.tgz",
+            "integrity": "sha1-rzD4DNS8HFssYiTkx5A63NlRTc0=",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.25",
-                "@types/express-serve-static-core": "^4.17.21",
+                "@types/express": "^5.0.6",
+                "@types/express-serve-static-core": "^5.1.1",
                 "@types/serve-index": "^1.9.4",
-                "@types/serve-static": "^1.15.5",
-                "@types/sockjs": "^0.3.36",
-                "@types/ws": "^8.5.10",
+                "@types/serve-static": "^2.2.0",
+                "@types/ws": "^8.18.1",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.2.1",
-                "chokidar": "^3.6.0",
-                "colorette": "^2.0.10",
+                "bonjour-service": "^1.3.0",
+                "chokidar": "^5.0.0",
                 "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.22.1",
-                "graceful-fs": "^4.2.6",
-                "http-proxy-middleware": "^2.0.9",
-                "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
-                "open": "^10.0.3",
-                "p-retry": "^6.2.0",
-                "schema-utils": "^4.2.0",
+                "express": "^5.2.1",
+                "graceful-fs": "^4.2.11",
+                "http-proxy-middleware": "^4.1.1",
+                "ipaddr.js": "^2.3.0",
+                "launch-editor": "^2.14.1",
+                "open": "^11.0.0",
+                "p-retry": "^8.0.0",
+                "schema-utils": "^4.3.3",
                 "selfsigned": "^5.5.0",
-                "serve-index": "^1.9.1",
-                "sockjs": "^0.3.24",
-                "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^7.4.2",
-                "ws": "^8.18.0"
+                "serve-index": "^1.9.2",
+                "tinyglobby": "^0.2.15",
+                "webpack-dev-middleware": "^8.0.3",
+                "ws": "^8.20.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 22.15.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": "^5.101.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -17156,48 +17245,26 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.8",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-            "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
         "node_modules/webpack-dev-server/node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha1-lJwSapI4qAeSvpoCZZNPCYrzaaU=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17208,20 +17275,20 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/memfs": {
-            "version": "4.57.8",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.8.tgz",
-            "integrity": "sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==",
+            "version": "4.67.0",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.67.0.tgz",
+            "integrity": "sha1-OpKO5DOSDwg0jFHtQzrEG8Q3Jyk=",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@jsonjoy.com/fs-core": "4.57.8",
-                "@jsonjoy.com/fs-fsa": "4.57.8",
-                "@jsonjoy.com/fs-node": "4.57.8",
-                "@jsonjoy.com/fs-node-builtins": "4.57.8",
-                "@jsonjoy.com/fs-node-to-fsa": "4.57.8",
-                "@jsonjoy.com/fs-node-utils": "4.57.8",
-                "@jsonjoy.com/fs-print": "4.57.8",
-                "@jsonjoy.com/fs-snapshot": "4.57.8",
+                "@jsonjoy.com/fs-core": "4.67.0",
+                "@jsonjoy.com/fs-fsa": "4.67.0",
+                "@jsonjoy.com/fs-node": "4.67.0",
+                "@jsonjoy.com/fs-node-builtins": "4.67.0",
+                "@jsonjoy.com/fs-node-to-fsa": "4.67.0",
+                "@jsonjoy.com/fs-node-utils": "4.67.0",
+                "@jsonjoy.com/fs-print": "4.67.0",
+                "@jsonjoy.com/fs-snapshot": "4.67.0",
                 "@jsonjoy.com/json-pack": "^1.11.0",
                 "@jsonjoy.com/util": "^1.9.0",
                 "glob-to-regex.js": "^1.0.1",
@@ -17232,15 +17299,12 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
             }
         },
         "node_modules/webpack-dev-server/node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17250,7 +17314,7 @@
         "node_modules/webpack-dev-server/node_modules/mime-types": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17265,47 +17329,61 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/open": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha1-iX5hMvmU01VMvPcuDfmPF2p+X2I=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.2.1",
+                "default-browser": "^5.4.0",
                 "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
                 "is-inside-container": "^1.0.0",
-                "wsl-utils": "^0.1.0"
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/webpack-dev-server/node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha1-+/H3GnJ4kdaFuxeG+bp0CE9uL5E=",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
-            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-8.1.1.tgz",
+            "integrity": "sha1-xOcDQJAf9MNJ/UK6oPRwJAGSkfQ=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "colorette": "^2.0.10",
-                "memfs": "^4.43.1",
-                "mime-types": "^3.0.1",
-                "on-finished": "^2.4.1",
+                "memfs": "^4.56.10",
+                "mime-types": "^3.0.2",
                 "range-parser": "^1.2.1",
-                "schema-utils": "^4.0.0"
+                "schema-utils": "^4.3.3"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 20.9.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^5.0.0"
+                "webpack": "^5.101.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -17421,31 +17499,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/websocket-driver": {
-            "version": "0.7.5",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
-            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "http-parser-js": ">=0.5.1",
-                "safe-buffer": ">=5.1.0",
-                "websocket-extensions": ">=0.1.1"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/websocket-extensions": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/which": {
@@ -17593,16 +17646,17 @@
             }
         },
         "node_modules/wsl-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha1-lHmDbd8DviZ6rTq/w8sfbgyfHtE=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-wsl": "^3.1.0"
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -17611,7 +17665,7 @@
         "node_modules/wsl-utils/node_modules/is-wsl": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17732,6 +17786,7 @@
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
             "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             }


### PR DESCRIPTION
Run non-breaking 'npm audit fix' on root (39 -> 22 vulnerabilities). Remaining vulnerabilities require breaking Angular major bumps and are left to dependabot PRs.

Normalize 151 internal registry hosts injected by audit fix (ms-feed-*.pkgs.visualstudio.com/1es-public/...) back to https://registry.npmjs.org/ so the public lockfile works for external contributors and public CI. Integrity hashes are unchanged.