### PR TITLE
fix: don't let telemetry timers block Angular from becoming stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ export class AppComponent {
 }
 ```
 
+## Avoiding Hydration / Stability Delays
+
+If your app uses Angular's SSR hydration, or anything else that waits on `ApplicationRef.isStable`/`whenStable()`,
+call `loadAppInsights()` itself outside Angular's zone. The SDK keeps its own timers alive in the background for as
+long as it's running (batching/retrying telemetry, polling for config changes, diagnostic logging), and if
+`loadAppInsights()` runs inside NgZone, those timers get scheduled inside NgZone too - which can keep Angular from
+ever reporting the app as stable.
+
+This plugin keeps its own telemetry-processing timers out of NgZone automatically (route-change tracking and
+`processTelemetry`), but it doesn't call `loadAppInsights()` for you, so that part is on your app:
+
+```js
+constructor(
+    private router: Router,
+    private ngZone: NgZone
+){
+    this.ngZone.runOutsideAngular(() => {
+        var angularPlugin = new AngularPlugin();
+        const appInsights = new ApplicationInsights({ config: {
+        instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
+        extensions: [angularPlugin],
+        extensionConfig: {
+            [angularPlugin.identifier]: { router: this.router }
+        }
+        } });
+        appInsights.loadAppInsights();
+    });
+}
+```
+
 To track uncaught exceptions, setup ApplicationinsightsAngularpluginErrorService in `app.module.ts`:
 
 > Note: When using the ErrorService there is an implicit dependency on the ```@microsoft/applicationinsights-analytics-js``` extension which is also include in the that your MUST include the ```@microsoft/applicationinsights-web``` Sku, so for uncaught exceptions to be tracked your project MUST be initialized to include the analytics package otherwise unhandled errors caught by the error service will not be sent

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "@angular/platform-browser-dynamic": "^21.2.19",
                 "@angular/router": "^21.2.19",
                 "@microsoft/applicationinsights-analytics-js": "^3.4.2",
+                "@microsoft/applicationinsights-web": "^3.4.2",
                 "@types/jasmine": "~3.6.0",
                 "@types/node": "^12.20.55",
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -2738,6 +2739,43 @@
                 "node": ">=14.17.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+            "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@es-joy/jsdoccomment": {
             "version": "0.41.0",
             "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
@@ -4426,12 +4464,63 @@
                 "tslib": ">= 1.0.0"
             }
         },
+        "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.3.tgz",
+            "integrity": "sha512-IA0puIUsScpHWMDpjeElE3ZO6XtezzzSZavI2uNpPtco4/mbFXxN/VyRa0CxFHFT9E2wtly5YFm++eX7iBG7Jg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.3",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-channel-js": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.3.tgz",
+            "integrity": "sha512-9EeGdGkpgmTH0UEAn9AwbSGfEAdPK1GQdZ1vmbsy+H4t01oFgW4drteykVvYUcXnNHNIjo4mI8hhN6taou5Ogg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.3",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
         "node_modules/@microsoft/applicationinsights-core-js": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.3.tgz",
             "integrity": "sha1-2tJKf5V4gfubq5ZDh2r6Wws54Lo=",
             "license": "MIT",
             "dependencies": {
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-dependencies-js": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.3.tgz",
+            "integrity": "sha512-1ZWWZ7h4uUs0Ir3n5GorRvrCEa3RkLc3MLJXcizxXgtPeICdcICmbokuG+CKM7s9ieOdlHG5Vf/X6sGlVlZygw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.4.3",
                 "@microsoft/applicationinsights-shims": "3.0.1",
                 "@microsoft/dynamicproto-js": "^2.0.3",
                 "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
@@ -4463,6 +4552,28 @@
             "license": "MIT",
             "dependencies": {
                 "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-web": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.3.tgz",
+            "integrity": "sha512-YoTXfma0VIL753BTuhikElkIEu2ZrTaGWslYVd5U5hEdzl7zrCvMik4FpEt2lY0q0GJjjFgqMcNoGWJG+9VKGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/applicationinsights-analytics-js": "3.4.3",
+                "@microsoft/applicationinsights-cfgsync-js": "3.4.3",
+                "@microsoft/applicationinsights-channel-js": "3.4.3",
+                "@microsoft/applicationinsights-core-js": "3.4.3",
+                "@microsoft/applicationinsights-dependencies-js": "3.4.3",
+                "@microsoft/applicationinsights-properties-js": "3.4.3",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.3",
+                "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": ">= 1.0.0"
             }
         },
         "node_modules/@microsoft/dynamicproto-js": {
@@ -17704,7 +17815,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tsyringe": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "@angular/platform-browser-dynamic": "^21.2.19",
         "@angular/router": "^21.2.19",
         "@microsoft/applicationinsights-analytics-js": "^3.4.2",
+        "@microsoft/applicationinsights-web": "^3.4.2",
         "@types/jasmine": "~3.6.0",
         "@types/node": "^12.20.55",
         "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.ts
@@ -34,6 +34,20 @@ const defaultAngularExtensionConfig: IConfigDefaults<IAngularExtensionConfig> = 
     errorServices: { blkVal: true, v: undefValue}
 });
 
+declare const Zone: any;
+
+// If code runs inside Angular's zone, any setTimeout/promise/etc it kicks off also
+// runs inside that zone. Angular waits for the zone to go quiet (no pending timers)
+// before it considers the app "stable" - that's what hydration and isStable/whenStable
+// wait on. The telemetry SDK keeps a recurring batch/retry timer alive to send events,
+// so if that timer is scheduled inside Angular's zone, the zone never goes quiet and
+// the app never becomes stable. Running our calls in the root zone instead keeps that
+// timer invisible to Angular, so it doesn't block stability.
+const isNgZoneEnabled = typeof Zone !== "undefined" && typeof Zone.root?.run === "function";
+function runOutsideAngular<T>(callback: () => T): T {
+    return isNgZoneEnabled ? Zone.root.run(callback) : callback();
+}
+
 @Component({
     selector: "lib-applicationinsights-angularplugin-js",
     template: "",
@@ -129,7 +143,7 @@ export class AngularPlugin extends BaseTelemetryPlugin {
                                             uri: _angularCfg.router.url,
                                             properties: { duration: 0 } // SPA route change loading durations are undefined, so send 0
                                         };
-                                        _self.trackPageView(pvt);
+                                        runOutsideAngular(() => _self.trackPageView(pvt));
                                     }
                                 }
                             });
@@ -186,7 +200,7 @@ export class AngularPlugin extends BaseTelemetryPlugin {
      * @param event The event that needs to be processed
      */
     processTelemetry(event: ITelemetryItem, itemCtx?: IProcessTelemetryContext) {
-        this.processNext(event, itemCtx);
+        runOutsideAngular(() => this.processNext(event, itemCtx));
     }
 
 

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.hydration.spec.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.hydration.spec.ts
@@ -1,0 +1,140 @@
+import { ApplicationRef, Component, NgZone, provideZoneChangeDetection } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { AngularPlugin } from "./applicationinsights-angularplugin-js.component";
+
+@Component({
+    template: "<p>Fake Home Component</p>"
+})
+class FakeHomeComponent { }
+
+@Component({
+    template: "<p>Fake About Component</p>"
+})
+class FakeAboutComponent { }
+
+// Regression test for #117: telemetry timers blocking Angular hydration/stability.
+//
+// Unlike the other spec file, this one does NOT stub out the channel/Sender - it
+// spins up a real ApplicationInsights instance (the same `loadAppInsights()` call
+// real apps make) so it exercises the actual timers the SDK schedules, not a mock.
+//
+// This plugin only controls two entry points - trackPageView (on route change) and
+// processTelemetry - so it can only keep timers that flow through *those* out of
+// Angular's zone (that includes the Sender's own batch/retry timer, since it's
+// armed downstream of processTelemetry). It has no way to touch timers that
+// AppInsightsCore itself arms directly inside loadAppInsights() (e.g. its
+// diagnosticLogInterval, which defaults to 10s and is exactly the kind of timer
+// #117 is about) - that call belongs to the consuming app, not this plugin. So the
+// test below has two phases: it calls loadAppInsights() itself outside NgZone (the
+// pattern the README recommends), then separately triggers a route change *inside*
+// NgZone (matching a real click/navigate() call) to prove this plugin's own fix
+// covers what's left - stability has to come back quickly after both.
+describe("AngularPlugin hydration regression (#117)", () => {
+    let fixture: ComponentFixture<AngularPlugin>;
+    let angularPlugin: AngularPlugin;
+    let router: Router;
+    let ngZone: NgZone;
+    let appRef: ApplicationRef;
+    let appInsights: ApplicationInsights;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [AngularPlugin],
+            imports: [
+                RouterTestingModule.withRoutes([
+                    { path: "home", component: FakeHomeComponent },
+                    { path: "about", component: FakeAboutComponent }
+                ])
+            ],
+            // TestBed defaults NgZone to a noop/zoneless stub. This regression is
+            // specifically about real zone.js behavior, so opt back into it - this
+            // is what every real bootstrapped app gets by default.
+            providers: [provideZoneChangeDetection()]
+        });
+
+        fixture = TestBed.createComponent(AngularPlugin);
+        angularPlugin = fixture.componentInstance;
+        router = TestBed.inject(Router);
+        ngZone = TestBed.inject(NgZone);
+        appRef = TestBed.inject(ApplicationRef);
+        fixture.detectChanges();
+    });
+
+    afterEach(() => {
+        // Tear down the real Sender so its timer doesn't keep firing (and hitting
+        // the network) after the test has finished.
+        appInsights?.unload(false);
+    });
+
+    it("becomes stable quickly when loadAppInsights() is called outside NgZone, per the recommended pattern", async () => {
+        // This is the pattern the README recommends: call loadAppInsights() itself
+        // via runOutsideAngular, the same way you'd wrap any other non-UI async work
+        // (an HTTP client's setup, a websocket, etc.) that shouldn't hold up Angular.
+        // That keeps AppInsightsCore's own init-time timers (diagnosticLogInterval,
+        // cfgSync polling) out of NgZone from the start. This plugin's fix then keeps
+        // the timers it's responsible for - the Sender's batch/retry timer, reached
+        // via trackPageView/processTelemetry - out of NgZone too, even though those
+        // calls happen synchronously as part of this same call chain.
+        ngZone.runOutsideAngular(() => {
+            appInsights = new ApplicationInsights({
+                config: {
+                    // Instrumentation key is a dummy; the endpoint is an address that
+                    // refuses connections instantly (nothing listens on port 9) so the
+                    // Sender's request fails fast instead of hanging - but it still
+                    // queues the pageview and arms its batch timer either way, which is
+                    // all this test needs.
+                    connectionString:
+                        "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=http://127.0.0.1:9/",
+                    extensions: [angularPlugin],
+                    extensionConfig: {
+                        [angularPlugin.identifier]: { router }
+                    }
+                }
+            });
+            appInsights.loadAppInsights();
+        });
+
+        const start = performance.now();
+        await appRef.whenStable();
+        const elapsed = performance.now() - start;
+
+        // AppInsightsCore's diagnosticLogInterval defaults to 10s and keeps
+        // re-arming itself for as long as the SDK is alive - that's the timer #117
+        // is really about, and it's why loadAppInsights() itself has to run outside
+        // NgZone, not just this plugin's own calls. 3s here is a generous margin:
+        // with every relevant timer kept out of NgZone, stability should come back
+        // almost immediately instead of waiting on (or never seeing) that 10s mark.
+        expect(elapsed).toBeLessThan(3000);
+
+        // Everything above ran inside runOutsideAngular, so it would stay out of
+        // NgZone even without this plugin's own fix - that part only proves the
+        // recommended pattern works. A route change is different: Router navigation
+        // triggered by a real user (a click, a programmatic navigate() call from a
+        // component) always runs *inside* NgZone, and that's exactly the call site
+        // this plugin's fix wraps (see runOutsideAngular in the component). So run
+        // the navigation itself inside NgZone here, on purpose, to prove that a
+        // plugin-only regression - forgetting the Zone.root.run() wrap on
+        // trackPageView - would show up here even with SDK init done correctly.
+        //
+        // The plugin ignores the *first* NavigationEnd it sees after init (it
+        // treats it as a duplicate of the page view already sent during init), so
+        // this navigates twice: the first is a throwaway to get past that, the
+        // second is the one that actually reaches the wrapped trackPageView call.
+        ngZone.run(() => {
+            router.navigate(["home"]);
+        });
+        await appRef.whenStable();
+
+        ngZone.run(() => {
+            router.navigate(["about"]);
+        });
+
+        const navStart = performance.now();
+        await appRef.whenStable();
+        const navElapsed = performance.now() - navStart;
+        expect(navElapsed).toBeLessThan(3000);
+    });
+});


### PR DESCRIPTION
App Insights keeps a repeating timer alive in the background to batch and retry sending events. If that timer gets scheduled while running inside Angular's zone, Angular never sees the zone go quiet, so it never thinks the app is "stable" - this blocks hydration and can delay it forever while telemetry keeps flowing in.

This runs trackPageView (on route change) and processTelemetry outside Angular's zone, using Zone.root.run the same way NgZone.runOutsideAngular does. Since the zone context carries through the rest of the synchronous call chain, this also moves the telemetry SDK's own batch/retry timer out of Angular's zone, without needing any changes to that SDK itself.

This does not affect the separate flush-on-unload code path, which already sends synchronously via sendBeacon and never touches this timer at all, so event delivery on page unload is unaffected.

Fixes #117.