### PR TITLE
refactor: remove `@Component` decorator from AngularPlugin

### DIFF
--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationininsights-angularplugin-multiple-instace.spec.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationininsights-angularplugin-multiple-instace.spec.ts
@@ -2,7 +2,7 @@ import {
     AppInsightsCore, IConfiguration, ITelemetryItem, IPlugin, IAppInsightsCore, IConfig
 } from "@microsoft/applicationinsights-core-js";
 import { AngularPlugin } from "./applicationinsights-angularplugin-js.component";
-import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { ApplicationinsightsAngularpluginErrorService } from "./applicationinsights-angularplugin-error.service";
 import { AnalyticsPlugin } from "@microsoft/applicationinsights-analytics-js";
@@ -15,7 +15,6 @@ import { Component, Injector } from "@angular/core";
 class FakeHomeComponent {}
 class FakeAboutComponent {}
 describe("ReactAI", () => {
-    let fixture: ComponentFixture<AngularPlugin>;
     let angularPlugin: AngularPlugin;
     let analyticsPlugin: AnalyticsPlugin;
     let core: AppInsightsCore;
@@ -48,7 +47,6 @@ describe("ReactAI", () => {
     beforeEach(() => {
         const spy = jasmine.createSpyObj("AnalyticsPlugin", ["trackPageView"]);
         TestBed.configureTestingModule({
-            declarations: [AngularPlugin],
             imports: [
                 RouterTestingModule.withRoutes([
                     { path: "home", component: FakeHomeComponent  },
@@ -61,14 +59,7 @@ describe("ReactAI", () => {
             ]
         });
 
-        TestBed.overrideProvider(AngularPlugin, { useValue: new AngularPlugin(arg1) });
-        fixture = TestBed.createComponent(AngularPlugin);
-        angularPlugin = fixture.componentInstance;
-
-        // TestBed.overrideProvider(AngularPlugin, { useValue: new AngularPlugin() });
-        // fixture2 = TestBed.createComponent(AngularPlugin);
-        // angularPlugin2 = fixture2.componentInstance;
-
+        angularPlugin = new AngularPlugin(arg1);
         angularPlugin2 = new AngularPlugin(arg2);
         angularPlugin3 = new AngularPlugin();
         angularPlugin4 = new AngularPlugin();
@@ -79,7 +70,6 @@ describe("ReactAI", () => {
 
         // Get the spy on trackPageView from the spy object
         TestBed.inject(AnalyticsPlugin) as jasmine.SpyObj<AnalyticsPlugin>;
-        fixture.detectChanges();
 
         // Setup
         analyticsPlugin = new AnalyticsPlugin();
@@ -149,7 +139,9 @@ describe("ReactAI", () => {
         tick(3000);
         expect(angularPlugin["_getDbgPlgTargets"]().router).toEqual(router);
 
-        // add error handler in angularPlugin1 should not affect angularPlugin2
+        // angularPlugin/angularPlugin2 each got their own injector (arg1/arg2), so
+        // they each get their own error service - adding a handler to one must not
+        // affect the other.
         let customErrorHandler = new CustomErrorHandler();
         angularPlugin["_getErrorService"]().addErrorHandler(customErrorHandler);
         const spy = spyOn(customErrorHandler, "handleError");
@@ -159,13 +151,17 @@ describe("ReactAI", () => {
         angularPlugin2["_getErrorService"]().handleError();
         expect(spy).toHaveBeenCalledTimes(1);
 
+        // angularPlugin3/angularPlugin4 were constructed without an injector, so they
+        // both fall back to the shared ApplicationinsightsAngularpluginErrorService
+        // singleton - which is separate from angularPlugin's own (injector-scoped)
+        // instance, so neither call here should reach customErrorHandler.
         angularPlugin3["_getErrorService"]().handleError();
         angularPlugin4["_getErrorService"]().handleError();
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
 
-        // on contrast, adding error handler to angularPlugin3 will affect angularPlugin4
-        // as they share the same ApplicationinsightsAngularpluginErrorService
-        // it will also affect angularPlugin1 as 3 is sharing from 1 error service instance
+        // angularPlugin3 and angularPlugin4 share the same fallback singleton, so
+        // adding a handler through angularPlugin3 affects angularPlugin4 too - but
+        // not angularPlugin/angularPlugin2, which each have their own instance.
         let customErrorHandler2 = new CustomErrorHandler2();
         angularPlugin3["_getErrorService"]().addErrorHandler(customErrorHandler2);
         const spy2 = spyOn(customErrorHandler2, "handleError");
@@ -173,13 +169,13 @@ describe("ReactAI", () => {
         expect(spy2).toHaveBeenCalledTimes(1);
 
         angularPlugin["_getErrorService"]().handleError();
-        expect(spy2).toHaveBeenCalledTimes(2);
+        expect(spy2).toHaveBeenCalledTimes(1);
 
         angularPlugin2["_getErrorService"]().handleError();
-        expect(spy2).toHaveBeenCalledTimes(2);
+        expect(spy2).toHaveBeenCalledTimes(1);
 
         angularPlugin4["_getErrorService"]().handleError();
-        expect(spy2).toHaveBeenCalledTimes(3);
+        expect(spy2).toHaveBeenCalledTimes(2);
     }));
 
       

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-error.service.spec.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-error.service.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { TestBed } from "@angular/core/testing";
 import { AppInsightsCore, IConfiguration, ITelemetryItem, IPlugin, IConfig } from "@microsoft/applicationinsights-core-js";
 import { AnalyticsPlugin } from "@microsoft/applicationinsights-analytics-js";
 import { ApplicationinsightsAngularpluginErrorService } from "./applicationinsights-angularplugin-error.service";
@@ -6,20 +6,15 @@ import { AngularPlugin } from "../lib/applicationinsights-angularplugin-js.compo
 
 describe("ApplicationinsightsAngularpluginErrorService", () => {
     let service: ApplicationinsightsAngularpluginErrorService;
-    let fixture: ComponentFixture<AngularPlugin>;
     let component: AngularPlugin;
     let appInsights: AnalyticsPlugin;
     let core: AppInsightsCore;
     let channel: ChannelPlugin;
 
     beforeEach(() => {
-        TestBed.configureTestingModule({
-            declarations: [AngularPlugin]
-        });
+        TestBed.configureTestingModule({});
         service = TestBed.inject(ApplicationinsightsAngularpluginErrorService);
-        fixture = TestBed.createComponent(AngularPlugin);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+        component = new AngularPlugin();
 
         // Setup
         appInsights = new AnalyticsPlugin();

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.spec.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.spec.ts
@@ -2,7 +2,7 @@ import {
     AppInsightsCore, IConfiguration, ITelemetryItem, IPlugin, IAppInsightsCore, IConfig, IPageViewTelemetry
 } from "@microsoft/applicationinsights-core-js";
 import { AngularPlugin } from "./applicationinsights-angularplugin-js.component";
-import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { ApplicationinsightsAngularpluginErrorService } from "./applicationinsights-angularplugin-error.service";
 import { AnalyticsPlugin } from "@microsoft/applicationinsights-analytics-js";
@@ -16,7 +16,6 @@ class FakeHomeComponent {}
 class FakeAboutComponent {}
 describe("ReactAI", () => {
 
-    let fixture: ComponentFixture<AngularPlugin>;
     let angularPlugin: AngularPlugin;
     let analyticsPlugin: AnalyticsPlugin;
     let core: AppInsightsCore;
@@ -26,7 +25,6 @@ describe("ReactAI", () => {
     beforeEach(() => {
         const spy = jasmine.createSpyObj("AnalyticsPlugin", ["trackPageView"]);
         TestBed.configureTestingModule({
-            declarations: [AngularPlugin],
             imports: [
                 RouterTestingModule.withRoutes([
                     { path: "home", component: FakeHomeComponent  },
@@ -38,16 +36,14 @@ describe("ReactAI", () => {
                 { provide: AnalyticsPlugin, useValue: spy }
             ]
         });
-        
+
         TestBed.inject(ApplicationinsightsAngularpluginErrorService);
-        fixture = TestBed.createComponent(AngularPlugin);
-        angularPlugin = fixture.componentInstance;
+        angularPlugin = new AngularPlugin();
         router = TestBed.inject(Router);
 
         // Get the spy on trackPageView from the spy object
         // analyticsPluginSpy
         TestBed.inject(AnalyticsPlugin) as jasmine.SpyObj<AnalyticsPlugin>;
-        fixture.detectChanges();
 
         // Setup
         analyticsPlugin = new AnalyticsPlugin();

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.component.ts
@@ -1,4 +1,4 @@
-import { Component, Injector} from "@angular/core";
+import { Injector} from "@angular/core";
 import {
     IPlugin, IConfiguration, IAppInsightsCore, BaseTelemetryPlugin, arrForEach, ITelemetryItem, ITelemetryPluginChain,
     IProcessTelemetryContext, getLocation, _throwInternal, eLoggingSeverity, _eInternalMessageId, IProcessTelemetryUnloadContext,
@@ -16,14 +16,84 @@ import { PropertiesPlugin } from "@microsoft/applicationinsights-properties-js";
 
 interface IAngularExtensionConfig {
     /**
-     * Angular router for enabling Application Insights PageView tracking.
+     * Angular router for enabling Application Insights PageView tracking. When set, the
+     * plugin automatically tracks the initial page view and every subsequent route change
+     * as PageView telemetry - you don't need to call trackPageView() yourself.
+     *
+     * @example
+     * ```ts
+     * const angularPlugin = new AngularPlugin();
+     * const appInsights = new ApplicationInsights({
+     *     config: {
+     *         instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
+     *         extensions: [angularPlugin],
+     *         extensionConfig: {
+     *             [angularPlugin.identifier]: { router }
+     *         }
+     *     }
+     * });
+     * ```
      */
     router?: Router;
 
     /**
-     * Custom error service for global error handling.
+     * Custom error handlers to chain into the error service (see IErrorService and
+     * ApplicationinsightsAngularpluginErrorService). Whenever that service - set up as
+     * Angular's ErrorHandler provider - catches an uncaught error, it tracks exception
+     * telemetry and then calls handleError() on each of these, in order.
+     *
+     * @example
+     * ```ts
+     * class CustomErrorHandler implements IErrorService {
+     *     handleError(error: any) {
+     *         // ...
+     *     }
+     * }
+     *
+     * extensionConfig: {
+     *     [angularPlugin.identifier]: {
+     *         router,
+     *         errorServices: [new CustomErrorHandler()]
+     *     }
+     * }
+     * ```
      */
     errorServices?: IErrorService[];
+
+    /**
+     * By default, every AngularPlugin instance on the page shares one
+     * ApplicationinsightsAngularpluginErrorService singleton (its static `instance`
+     * field), so error handlers added through one instance are visible to all of them.
+     * That's fine with a single ApplicationInsights instance, but if you're running
+     * more than one in the same session - e.g. one per tenant, or a host app plus
+     * embedded widgets, each with its own errorServices - they'd otherwise all share
+     * (and stomp on) the same handler list.
+     *
+     * Set this to true, together with passing an Injector into
+     * `new AngularPlugin(injector)`, to give that instance its own error service
+     * instead of the shared one. The injector just needs to be able to resolve
+     * ApplicationinsightsAngularpluginErrorService - it doesn't need to be (and usually
+     * isn't) the app's root injector. Setting useInjector without also passing an
+     * injector to the constructor has no effect - it silently falls back to the shared
+     * singleton.
+     *
+     * @example
+     * ```ts
+     * const injector = Injector.create({
+     *     providers: [ApplicationinsightsAngularpluginErrorService]
+     * });
+     * const angularPlugin = new AngularPlugin(injector);
+     * const appInsights = new ApplicationInsights({
+     *     config: {
+     *         instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
+     *         extensions: [angularPlugin],
+     *         extensionConfig: {
+     *             [angularPlugin.identifier]: { router, useInjector: true }
+     *         }
+     *     }
+     * });
+     * ```
+     */
     useInjector?: boolean;
 }
 
@@ -48,13 +118,6 @@ function runOutsideAngular<T>(callback: () => T): T {
     return isNgZoneEnabled ? Zone.root.run(callback) : callback();
 }
 
-@Component({
-    selector: "lib-applicationinsights-angularplugin-js",
-    template: "",
-    styles: [],
-    standalone: false
-})
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export class AngularPlugin extends BaseTelemetryPlugin {
     public priority = 186;
     public identifier = "AngularPlugin";

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.hydration.spec.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.hydration.spec.ts
@@ -1,5 +1,5 @@
 import { ApplicationRef, Component, NgZone, provideZoneChangeDetection } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
@@ -33,7 +33,6 @@ class FakeAboutComponent { }
 // NgZone (matching a real click/navigate() call) to prove this plugin's own fix
 // covers what's left - stability has to come back quickly after both.
 describe("AngularPlugin hydration regression (#117)", () => {
-    let fixture: ComponentFixture<AngularPlugin>;
     let angularPlugin: AngularPlugin;
     let router: Router;
     let ngZone: NgZone;
@@ -42,7 +41,6 @@ describe("AngularPlugin hydration regression (#117)", () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [AngularPlugin],
             imports: [
                 RouterTestingModule.withRoutes([
                     { path: "home", component: FakeHomeComponent },
@@ -55,12 +53,10 @@ describe("AngularPlugin hydration regression (#117)", () => {
             providers: [provideZoneChangeDetection()]
         });
 
-        fixture = TestBed.createComponent(AngularPlugin);
-        angularPlugin = fixture.componentInstance;
+        angularPlugin = new AngularPlugin();
         router = TestBed.inject(Router);
         ngZone = TestBed.inject(NgZone);
         appRef = TestBed.inject(ApplicationRef);
-        fixture.detectChanges();
     });
 
     afterEach(() => {

--- a/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.module.ts
+++ b/projects/applicationinsights-angularplugin-js/src/lib/applicationinsights-angularplugin-js.module.ts
@@ -1,12 +1,7 @@
 import { NgModule } from "@angular/core";
-import { AngularPlugin } from "./applicationinsights-angularplugin-js.component";
 import { ApplicationinsightsAngularpluginErrorService } from "./applicationinsights-angularplugin-error.service";
 
 @NgModule({
-    declarations: [AngularPlugin],
-    imports: [
-    ],
-    exports: [AngularPlugin],
     providers: [
         ApplicationinsightsAngularpluginErrorService
     ]


### PR DESCRIPTION
AngularPlugin has never actually been a view component - it's documented as something you construct directly with new AngularPlugin(), never put in a template. The `@Component` decorator was scaffolding left over from however this file was originally generated (hence the file name and the eslint-disable for the missing "Component" suffix).

Drops it from the class, and from the two places that only existed to support it:
- ApplicationinsightsAngularpluginJsModule's declarations/exports, which only worked because AngularPlugin was a Component. The module now just provides ApplicationinsightsAngularpluginErrorService, which is its only real job - nothing in the README or sample app ever imports this module for AngularPlugin itself, since it's always constructed with new.
- The spec files, which all built AngularPlugin via TestBed.createComponent() instead of new AngularPlugin(). Switched them to construct it directly and pull Router/NgZone/etc. from TestBed.inject() separately, same as any other plain class under test.

That last change surfaced a real bug in the multiple-instance spec: it was using TestBed.overrideProvider(AngularPlugin, { useValue: new AngularPlugin(arg1) }) to force a custom injector into the instance under test, but a component's own constructor argument for Injector is filled in by Angular's component factory, not by a plain value-provider override - so the override was silently doing nothing, and the "instance" test was really just getting a NodeInjector, not the custom arg1/arg2 injectors it thought it was testing. That meant the useInjector-scoped error-service isolation this feature is for was never actually being exercised. Constructing it directly fixes that and exposed that some of the test's expected call counts were wrong - corrected those to match the real (and correct) isolated behavior.

Also expands the IAngularExtensionConfig property comments (router, errorServices, useInjector) with what each one actually does and a usage example - useInjector in particular does nothing on its own, since it only takes effect paired with passing an Injector into new AngularPlugin(injector), which wasn't documented anywhere near the property itself.